### PR TITLE
fix(product): detail page layout — side-by-side gallery and info, class-based gallery styles

### DIFF
--- a/client/src/app/assets/css/product.css
+++ b/client/src/app/assets/css/product.css
@@ -15,8 +15,95 @@
   display: flex;
   flex-direction: row;
   align-items: flex-start;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 2rem;
+}
+
+.product-detail-section .leftImages {
+  flex-shrink: 0;
+  max-width: 560px;
+  width: 100%;
+}
+
+.product-detail-section .imageFlexRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.product-detail-section .mainImageContainer {
+  position: relative;
+  width: 420px;
+  max-width: calc(100vw - 160px);
+  flex-shrink: 0;
+}
+
+.product-detail-main-image {
+  border-radius: 10px;
+  object-fit: contain;
+  border: 1px solid #eee;
+  cursor: pointer;
+  width: 100%;
+  max-width: 420px;
+  height: 420px;
+  background: #fff;
+}
+
+.product-detail-fullscreen-btn {
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  background: rgba(0, 0, 0, 0.6);
+  border: none;
+  border-radius: 50%;
+  width: 38px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.product-detail-thumbnails {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.product-detail-thumb {
+  border: 1px solid #eee;
+  border-radius: 6px;
+  cursor: pointer;
+  padding: 2px;
+  background: #fff;
+}
+
+.product-detail-thumb:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.product-detail-thumb--selected {
+  border: 2px solid #2563eb;
+  background: #e0e7ff;
+}
+
+.product-detail-thumb-image {
+  border-radius: 6px;
+  object-fit: cover;
+  width: 72px;
+  height: 72px;
+  display: block;
+}
+
+.product-detail-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.product-detail-info > h1:first-of-type {
+  margin-top: 0;
 }
 
 .you-might-like-slider {
@@ -665,6 +752,16 @@
   .product-detail-section .mainContent {
     flex-direction: column;
     gap: 1.25rem;
+  }
+
+  .product-detail-section .mainImageContainer {
+    max-width: min(420px, calc(100vw - 120px));
+  }
+
+  .product-detail-main-image {
+    height: auto;
+    min-height: 200px;
+    aspect-ratio: 1;
   }
 
   .products-page-container {

--- a/client/src/app/products/[slug]/page.js
+++ b/client/src/app/products/[slug]/page.js
@@ -394,27 +394,24 @@ export default function ProductDetail() {
       )}
       <div className="container product-detail-section">
         <div className="mainContent">
-          {/* Left: Images */}
-          <div className="leftImages" style={{ maxWidth: 560, width: '100%' }}>
-            <div className="imageFlexRow" style={{ display: 'flex', alignItems: 'flex-start', gap: 14 }}>
-              <div className="mainImageContainer" style={{ position: 'relative', width: 420, maxWidth: 'calc(100vw - 160px)' }}>
-                <Image src={productImages[selected]} alt={`${product.name} ${selected + 1}`} width={420} height={420} unoptimized style={{ borderRadius: 10, objectFit: 'contain', border: '1px solid #eee', cursor: 'pointer', width: '100%', maxWidth: 420, height: 420, background: '#fff' }} onClick={() => setFullscreen(true)} />
-                <button onClick={() => setFullscreen(true)} title="View Fullscreen" style={{ position: 'absolute', bottom: 16, right: 16, background: 'rgba(0,0,0,0.6)', border: 'none', borderRadius: '50%', width: 38, height: 38, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', zIndex: 2 }}>
+          <div className="leftImages">
+            <div className="imageFlexRow">
+              <div className="mainImageContainer">
+                <Image src={productImages[selected]} alt={`${product.name} ${selected + 1}`} width={420} height={420} unoptimized className="product-detail-main-image" onClick={() => setFullscreen(true)} />
+                <button type="button" onClick={() => setFullscreen(true)} title="View Fullscreen" className="product-detail-fullscreen-btn">
                   <svg width="22" height="22" fill="#fff" viewBox="0 0 24 24"><path d="M9 3H5a2 2 0 0 0-2 2v4a1 1 0 1 0 2 0V5h4a1 1 0 1 0 0-2zm6 0a1 1 0 1 0 0 2h4v4a1 1 0 1 0 2 0V5a2 2 0 0 0-2-2h-4zm5 14a1 1 0 0 0-1 1v4h-4a1 1 0 1 0 0 2h4a2 2 0 0 0 2-2v-4a1 1 0 0 0-1-1zm-16 1a1 1 0 0 0-1 1v4a2 2 0 0 0 2 2h4a1 1 0 1 0 0-2H5v-4a1 1 0 0 0-1-1z"/></svg>
                 </button>
               </div>
-              <div className="thumbnails" style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-                {/* Thumbnails */}
+              <div className="thumbnails product-detail-thumbnails">
                 {galleryThumbnails.map((img, idx) => (
-                  <div key={img} style={{ border: idx === selected ? '2px solid #2563eb' : '1px solid #eee', borderRadius: 6, cursor: 'pointer', padding: 2, background: idx === selected ? '#e0e7ff' : '#fff' }} onClick={() => setSelected(idx)}>
-                    <Image src={img} alt={`${product.name} thumb ${idx + 1}`} width={72} height={72} unoptimized style={{ borderRadius: 6, objectFit: 'cover', width: 72, height: 72 }} />
+                  <div key={img} className={`product-detail-thumb ${idx === selected ? 'product-detail-thumb--selected' : ''}`} role="button" tabIndex={0} onClick={() => setSelected(idx)} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelected(idx); } }}>
+                    <Image src={img} alt={`${product.name} thumb ${idx + 1}`} width={72} height={72} unoptimized className="product-detail-thumb-image" />
                   </div>
                 ))}
               </div>
             </div>
           </div>
-          {/* Right: Details */}
-          <div style={{ flex: 1 }}>
+          <div className="product-detail-info">
             <h1 style={{ fontSize: '2.1rem', marginBottom: 8, fontWeight: 700 }}>{product.name}</h1>
             <div style={{ color: '#2563eb', fontWeight: 600, marginBottom: 6 }}>{product.specifications?.brand || product.category}</div>
             <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>


### PR DESCRIPTION
1. Inline styles on the main image, full screen button and thumbnails were replaced with CSS classes.
2. Thumbnail wrappers use role="buttom", tabIndex{0} , and onKeyDown for basic keyboard access.
3. The fullscreen control is explicitly type="button".
4. mainContent is a horizontal flex: gallery ( leftImages ) left, details ( product-detail-info ) right.
5. justify-content: flex-start (instead of space-between) so the info block sits next to the gallery with a fixed gap, instead of being pushed to the far side of the row.
6. product-detail-info uses flex: 1 and min-width: 0 so the text column fills remaining space and wraps correctly.
7. product-detail-info > h1:first-of-type { margin-top: 0 } removes default heading top margin so the title lines up with the top of the image area.
8. At max-width: 768px, mainContent switches to flex-direction: column so gallery stacks above the copy on small screens.
9. Main image container / image rules in that breakpoint keep the image sizing sensible on narrow viewports.