### PR TITLE
synonim/typo keywords

### DIFF
--- a/client/src/app/components/Category/Category.js
+++ b/client/src/app/components/Category/Category.js
@@ -6,6 +6,7 @@ import { useCart } from '@/app/components/cart/Cart';
 import { FaSearch, FaTimes } from 'react-icons/fa';
 import '@/app/assets/css/product.css';
 import '@/app/assets/css/categoryPage.css';
+import { productMatchesSearchQuery } from '@/app/utils/productSearch';
 
 const normalizeProductImagePath = (value) => {
   if (typeof value !== 'string') return '/Pictures/placeholder.jpg';
@@ -185,15 +186,9 @@ const CategoryPage = () => {
   const clearSearch = () => setSearchQuery('');
 
   const filteredProducts = useMemo(() => {
-    const term = searchQuery.trim().toLowerCase();
-    if (!term) return products;
+    if (!searchQuery.trim()) return products;
 
-    return products.filter((product) => {
-      const name = String(product?.name || '').toLowerCase();
-      const description = String(product?.description || '').toLowerCase();
-      const category = String(product?.category || '').toLowerCase();
-      return name.includes(term) || description.includes(term) || category.includes(term);
-    });
+    return products.filter((product) => productMatchesSearchQuery(product, searchQuery));
   }, [products, searchQuery]);
 
   const groupedProducts = useMemo(() => {

--- a/client/src/app/page.js
+++ b/client/src/app/page.js
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useCart } from '@/app/components/cart/Cart';
 import { FaSearch, FaTimes } from 'react-icons/fa';
 import { useSearchParams } from 'next/navigation';
+import { productMatchesSearchQuery } from '@/app/utils/productSearch';
 
 const normalizeProductImagePath = (value) => {
     if (typeof value !== 'string') return '/Pictures/placeholder.jpg';
@@ -115,16 +116,9 @@ const Products = () => {
     }, []);
 
     // Filter products based on search query (same logic as products page)
-    const filteredProducts = products.filter(product => {
-        if (!searchQuery) return true;
-        
-        const searchTerm = searchQuery.toLowerCase();
-        return (
-            product.name.toLowerCase().includes(searchTerm) ||
-            product.description.toLowerCase().includes(searchTerm) ||
-            product.category.toLowerCase().includes(searchTerm)
-        );
-    });
+    const filteredProducts = products.filter((product) =>
+        productMatchesSearchQuery(product, searchQuery)
+    );
 
     const productsByCategory = useMemo(() => {
         return filteredProducts.reduce((acc, product) => {

--- a/client/src/app/products/page.js
+++ b/client/src/app/products/page.js
@@ -6,6 +6,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useCart } from '@/app/components/cart/Cart';
 import '../assets/css/product.css';
+import { productMatchesSearchQuery } from '@/app/utils/productSearch';
 
 const normalizeProductImagePath = (value) => {
     if (typeof value !== 'string') return '/Pictures/placeholder.jpg';
@@ -142,12 +143,10 @@ if (filters.inStock) {
     filtered = filtered.filter(product => product.stockQuantity > 0);
 }
 
-// Apply search filter
+// Apply search filter (includes synonym / typo keywords)
 if (filters.search) {
-    const searchTerm = filters.search.toLowerCase();
-    filtered = filtered.filter(product => 
-        product.name.toLowerCase().includes(searchTerm) ||
-        product.description.toLowerCase().includes(searchTerm)
+    filtered = filtered.filter((product) =>
+        productMatchesSearchQuery(product, filters.search)
     );
 }
 

--- a/client/src/app/utils/productSearch.js
+++ b/client/src/app/utils/productSearch.js
@@ -1,0 +1,62 @@
+/**
+ * Synonym / typo groups for storefront search. If the user's query relates to a group
+ * and the product text matches any variant in that group, the product matches.
+ */
+export const PRODUCT_SEARCH_SYNONYM_GROUPS = [
+  ['playstation', 'play station', 'plastation'],
+  [
+    'earrings',
+    'earings',
+    'earing',
+    'necklaces',
+    'necklace',
+    'neklace',
+    'neklaces',
+    'neclace',
+    'neclaces',
+  ],
+  ['watch', 'watches', 'wotch', 'wotches'],
+];
+
+const MIN_SUBSTRING_QUERY_LEN = 4;
+
+function queryReferencesSynonymGroup(searchTerm, group) {
+  return group.some((syn) => {
+    if (searchTerm.includes(syn)) return true;
+    if (searchTerm.length >= MIN_SUBSTRING_QUERY_LEN && syn.includes(searchTerm)) return true;
+    return false;
+  });
+}
+
+function haystackMatchesSynonymGroup(haystack, group) {
+  return group.some((syn) => haystack.includes(syn));
+}
+
+/**
+ * @param {object} product
+ * @param {string} searchQuery raw user input
+ * @returns {boolean}
+ */
+export function productMatchesSearchQuery(product, searchQuery) {
+  const raw = typeof searchQuery === 'string' ? searchQuery.trim() : '';
+  if (!raw) return true;
+
+  const searchTerm = raw.toLowerCase();
+  const name = String(product?.name ?? '').toLowerCase();
+  const description = String(product?.description ?? '').toLowerCase();
+  const category = String(product?.category ?? '').toLowerCase();
+  const haystack = `${name} ${description} ${category}`;
+
+  if (haystack.includes(searchTerm)) return true;
+
+  for (const group of PRODUCT_SEARCH_SYNONYM_GROUPS) {
+    if (
+      queryReferencesSynonymGroup(searchTerm, group) &&
+      haystackMatchesSynonymGroup(haystack, group)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
1. Added client/src/app/utils/productSearch.js file for central product searching, with synonym/ typo groups for the  products I currently have.
2. Updated product/page.js. Catalog search uses productMatchesSearchQuery.
3. Updated app/pages.js file home/featured search (including ?search) uses the same helper so behavior matches the product page.
4. Updated app/components/category/categoryy.js file. Category page search uses the same helper.
