### PR TITLE
refreshing an expired access token

### DIFF
--- a/client/src/app/utils/userAuthFetch.js
+++ b/client/src/app/utils/userAuthFetch.js
@@ -87,3 +87,15 @@ export async function fetchWithUserAuth(url, options = {}) {
   } catch {
     return res;
   }
+
+  if (!isAccessTokenExpiredPayload(body)) {
+    return res;
+  }
+
+  try {
+    await refreshUserAccessToken();
+    return fetch(fullUrl, buildInit());
+  } catch {
+    return res;
+  }
+}


### PR DESCRIPTION
1. Check if the Token expired.
2. Try to refresh the Token.
3. Refresh the access Token:
- sends the refresh token to the backend.
- backend verifies it.
- backend generates a new access token.
- new token is stored in localStorage or cookies.
4. Retry the original request.
5. If refresh fails:
- Refresh token expired.
- User session invalid.
- Server error.
- Network issue.