### PR TITLE
logout and account

### DIFF
--- a/server/src/controllers/userController.js
+++ b/server/src/controllers/userController.js
@@ -1,4 +1,8 @@
 const User = require('../models/user');
+const {
+    MAX_PROFILE_IMAGES,
+    deleteLocalUploadIfOwned
+} = require('../utilities/profileImageStorage');
 
 const PROFILE_FIELDS = '-password -refreshToken -refreshTokenExpiry -tokenBlacklist -resetPasswordToken -resetPasswordExpires';
 
@@ -185,7 +189,7 @@ const updateAddress = async (req, res, next) => {
     }
 };
 
-//Delete a single address
+// Delete a single address
 const deleteAddress = async (req, res, next) => {
     try {
         const { addressId } = req.params;
@@ -215,7 +219,70 @@ const deleteAddress = async (req, res, next) => {
     }
 };
 
+// Upload avatar image
+const uploadAvatar = async (req, res, next) => {
+    try {
+        const uploaded = req.uploadedFiles?.[0];
+        if (!uploaded) {
+            return res.status(400).json({ message: 'Image file is required' });
+        }
 
+        const user = await User.findById(req.user._id);
+        if (!user) {
+            return res.status(404).json({ message: 'User not found' });
+        }
+
+        if (user.avatar) {
+            await deleteLocalUploadIfOwned(user.avatar, req.user._id);
+        }
+
+        user.avatar = uploaded.url;
+        await user.save();
+
+        const updatedUser = await fetchProfile(req.user._id);
+        res.status(201).json({
+            message: 'Avatar uploaded successfully',
+            url: uploaded.url,
+            user: updatedUser
+        });
+    } catch (error) {
+        next(error);
+    }
+};
+
+// Upload one or more profile gallery images
+const uploadProfileImages = async (req, res, next) => {
+    try {
+        const uploadedFiles = req.uploadedFiles || [];
+        if (uploadedFiles.length === 0) {
+            return res.status(400).json({ message: 'At least one image is required' });
+        }
+
+        const user = await User.findById(req.user._id);
+        if (!user) {
+            return res.status(404).json({ message: 'User not found' });
+        }
+
+        const currentImages = user.profileImage || [];
+        if (currentImages.length + uploadedFiles.length > MAX_PROFILE_IMAGES) {
+            return res.status(400).json({
+                message: `You can only store up to ${MAX_PROFILE_IMAGES} profile images`
+            });
+        }
+
+        user.profileImage = [...currentImages, ...uploadedFiles.map((file) => file.url)];
+        await user.save();
+
+        const updatedUser = await fetchProfile(req.user._id);
+        res.status(201).json({
+            message: 'Profile images uploaded successfully',
+            urls: uploadedFiles.map((file) => file.url),
+            user: updatedUser
+        });
+    } catch (error) {
+        next(error);
+    }
+};
 
 // New function to get user details
 exports.getUserDetails = async (userId) => {
@@ -233,5 +300,7 @@ module.exports = {
     changePassword,
     addAddress,
     updateAddress,
-    deleteAddress
+    deleteAddress,
+    uploadAvatar,
+    uploadProfileImages
 };

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -49,6 +49,9 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
 
+// Serve uploaded profile images
+app.use('/uploads', express.static(path.join(__dirname, '../uploads')));
+
 // Global error handling middleware
 app.use((err, req, res, next) => {
   console.error(err);

--- a/server/src/middleware/profileUpload.js
+++ b/server/src/middleware/profileUpload.js
@@ -1,0 +1,81 @@
+const formidable = require('formidable');
+const {
+    UPLOAD_DIR,
+    MAX_FILE_SIZE,
+    ensureUploadDir,
+    validateImageFile,
+    finalizeUpload,
+    cleanupUploadedFiles
+} = require('../utilities/profileImageStorage');
+
+const normalizeUploadedFiles = (files) => {
+    if (!files) return [];
+
+    return Object.values(files).flatMap((entry) => (Array.isArray(entry) ? entry : [entry]));
+};
+
+const createProfileUploadMiddleware = ({ fieldName, maxFiles = 1, multiples = false }) => {
+    return (req, res, next) => {
+        const contentType = req.headers['content-type'] || '';
+        if (!contentType.includes('multipart/form-data')) {
+            return res.status(400).json({ message: 'Content-Type must be multipart/form-data' });
+        }
+
+        ensureUploadDir();
+
+        const form = formidable({
+            uploadDir: UPLOAD_DIR,
+            keepExtensions: true,
+            maxFiles,
+            maxFileSize: MAX_FILE_SIZE,
+            multiples
+        });
+
+        form.parse(req, async (err, fields, files) => {
+            if (err) {
+                return res.status(400).json({ message: err.message || 'Upload failed' });
+            }
+
+            const rawFiles = normalizeUploadedFiles(files[fieldName]);
+            if (rawFiles.length === 0) {
+                return res.status(400).json({ message: `Missing file field: ${fieldName}` });
+            }
+
+            for (const file of rawFiles) {
+                const validation = validateImageFile(file);
+                if (!validation.ok) {
+                    await cleanupUploadedFiles(rawFiles);
+                    return res.status(400).json({ message: validation.message });
+                }
+            }
+
+            try {
+                req.uploadedFiles = await Promise.all(
+                    rawFiles.map((file) => finalizeUpload(file, req.user._id))
+                );
+                req.uploadFields = fields;
+                next();
+            } catch (uploadError) {
+                await cleanupUploadedFiles(rawFiles);
+                next(uploadError);
+            }
+        });
+    };
+};
+
+const parseAvatarUpload = createProfileUploadMiddleware({
+    fieldName: 'image',
+    maxFiles: 1,
+    multiples: false
+});
+
+const parseProfileImagesUpload = createProfileUploadMiddleware({
+    fieldName: 'images',
+    maxFiles: 5,
+    multiples: true
+});
+
+module.exports = {
+    parseAvatarUpload,
+    parseProfileImagesUpload
+};

--- a/server/src/routes/user.js
+++ b/server/src/routes/user.js
@@ -10,13 +10,16 @@ const {
   validateAddressId
 } = require('../utilities/validation');
 const { authMiddleware } = require('../middleware/authMiddleware');
+const { parseAvatarUpload, parseProfileImagesUpload } = require('../middleware/profileUpload');
 const {
   getUser,
   updateUser,
   changePassword,
   addAddress,
   updateAddress,
-  deleteAddress
+  deleteAddress,
+  uploadAvatar,
+  uploadProfileImages
 } = require('../controllers/userController');
 
 // Route to get the user's profile (Protected route)
@@ -27,6 +30,10 @@ router.put('/profile', authMiddleware, validateUpdateProfile, validate, updateUs
 
 // Route to change password from profile settings (Protected route)
 router.put('/profile/password', authMiddleware, validateChangePassword, validate, changePassword);
+
+// Profile image uploads (Protected routes)
+router.post('/profile/upload/avatar', authMiddleware, parseAvatarUpload, uploadAvatar);
+router.post('/profile/upload/images', authMiddleware, parseProfileImagesUpload, uploadProfileImages);
 
 // Address management (Protected routes)
 router.post('/profile/addresses', authMiddleware, validateAddAddress, validate, addAddress);

--- a/server/src/utilities/profileImageStorage.js
+++ b/server/src/utilities/profileImageStorage.js
@@ -1,0 +1,92 @@
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const UPLOAD_DIR = path.join(__dirname, '../../uploads/profile');
+const MAX_FILE_SIZE = 5 * 1024 * 1024;
+const MAX_PROFILE_IMAGES = 10;
+const ALLOWED_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/gif']);
+const ALLOWED_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.webp', '.gif']);
+
+const getPublicBaseUrl = () =>
+    (process.env.API_PUBLIC_URL || `http://localhost:${process.env.PORT || 5000}`).replace(/\/$/, '');
+
+const ensureUploadDir = () => {
+    fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+};
+
+const buildPublicUrl = (filename) => `${getPublicBaseUrl()}/uploads/profile/${filename}`;
+
+const validateImageFile = (file) => {
+    if (!file) {
+        return { ok: false, message: 'Image file is required' };
+    }
+
+    const ext = path.extname(file.originalFilename || '').toLowerCase();
+    if (!ALLOWED_EXTENSIONS.has(ext)) {
+        return { ok: false, message: 'Only JPG, PNG, WEBP, and GIF images are allowed' };
+    }
+
+    if (file.mimetype && !ALLOWED_MIME_TYPES.has(file.mimetype)) {
+        return { ok: false, message: 'Invalid image type' };
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+        return { ok: false, message: 'Image must be 5MB or smaller' };
+    }
+
+    return { ok: true };
+};
+
+const finalizeUpload = async (file, userId) => {
+    const ext = path.extname(file.originalFilename || '').toLowerCase();
+    const filename = `${userId}-${Date.now()}-${crypto.randomBytes(4).toString('hex')}${ext}`;
+    const destination = path.join(UPLOAD_DIR, filename);
+
+    await fs.promises.rename(file.filepath, destination);
+
+    return {
+        filename,
+        filepath: destination,
+        url: buildPublicUrl(filename)
+    };
+};
+
+const deleteLocalUploadIfOwned = async (url, userId) => {
+    if (!url || typeof url !== 'string') return;
+
+    const prefix = `${getPublicBaseUrl()}/uploads/profile/`;
+    if (!url.startsWith(prefix)) return;
+
+    const filename = path.basename(url);
+    if (!filename.startsWith(String(userId))) return;
+
+    const filePath = path.join(UPLOAD_DIR, filename);
+    try {
+        await fs.promises.unlink(filePath);
+    } catch (error) {
+        if (error.code !== 'ENOENT') {
+            console.error('Failed to delete profile image:', error.message);
+        }
+    }
+};
+
+const cleanupUploadedFiles = async (files = []) => {
+    await Promise.all(
+        files
+            .filter((file) => file?.filepath)
+            .map((file) => fs.promises.unlink(file.filepath).catch(() => {}))
+    );
+};
+
+module.exports = {
+    UPLOAD_DIR,
+    MAX_FILE_SIZE,
+    MAX_PROFILE_IMAGES,
+    ensureUploadDir,
+    buildPublicUrl,
+    validateImageFile,
+    finalizeUpload,
+    deleteLocalUploadIfOwned,
+    cleanupUploadedFiles
+};


### PR DESCRIPTION
1. Separated account, sign-in and log out.
- Account only navigates to account.
- Log out button only handles sign out.
- Sign in only shown when logged out.
2. Fixed logout flow
- Calls user and admin sign out APIs with a 5 seconds timeout.
- Clears token, userId, admin Token and adminRole from localStorage.
- Dispatches horizon-auth-change so the navbar updates.
- Mobile menu adds separate account and log out items when logged in.
3. CSS updates.
- Removed global overflow-x; hidden on html/body because it was clipping navbar icons.
- Styles logout, account, sign in and mobile menu logout button.
- Logout placed before account on mobile so it stays visible.
4. Accounts page has been commenced