### PR TITLE
Translation API, Cache, source language and failed translation

### DIFF
--- a/client/src/app/i18n/translator.js
+++ b/client/src/app/i18n/translator.js
@@ -1,0 +1,6 @@
+const ENDPOINT =  'https://api.mymemory.translated.net/get';
+const STORAGE_KEY = 'i18nMtCache';
+const SOURCE_LANG = 'eng'
+
+//How long before a failed translation may be retrieved.
+const RETRY_AFTER_MS = 60 * 1000; // 1 minute


### PR DESCRIPTION
1. API 'https://api.mymemory.translated.net/get'
2. Storage key 'i18nMtCache'
3. Source language is English
4. Failed translation will be retrieved in a minute