### PR TITLE
initialize the translation cache

### DIFF
--- a/client/src/app/i18n/translator.js
+++ b/client/src/app/i18n/translator.js
@@ -36,3 +36,31 @@ const persist = () => {
     // Ignore storage failures (quota / private mode).
   }
 };
+
+/** Load persisted translations into memory once (browser-only, sync). */
+export function initTranslationCache() {
+  if (loaded || typeof window === 'undefined') return false;
+  loaded = true;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const obj = JSON.parse(raw);
+      Object.entries(obj).forEach(([key, value]) => {
+        if (typeof value === 'string') memoryCache.set(key, value);
+      });
+      return memoryCache.size > 0;
+    }
+  } catch {
+    // Ignore malformed cache.
+  }
+  return false;
+}
+
+export function subscribeTranslations(callback) {
+  subscribers.add(callback);
+  return () => subscribers.delete(callback);
+}
+
+export function getCachedTranslation(lang, text) {
+  return memoryCache.get(cacheKey(lang, text));
+}


### PR DESCRIPTION
1. initTranslationCache()
- Read saved translations from localStorage.
- Load them into memoryCache.
- Ensure this happens only once.
2. Prevent duplicate initialization.
3. Mark cache as loaded.
4. Read from localStorage.
5. Convert JSON into an object.
6. Restore the Map.
7. Verify value are strings.
8. Return success status.
9. Error handling.

--------------------------
1. subscribeTranslations()

--------------------------
1. getCachedTranslation()
- Generate key.
- Lookup in cache.
- If not found, return undefined.
