### PR TITLE
disable super admin 2factor

### DIFF
--- a/server/src/controllers/superAdminProfileController.js
+++ b/server/src/controllers/superAdminProfileController.js
@@ -266,3 +266,45 @@ exports.verifySuperAdminTwoFactor = async (req, res) => {
         res.status(500).json({ success: false, error: 'Server error', message: error.message });
     }
 };
+
+exports.disableSuperAdminTwoFactor = async (req, res) => {
+    try {
+        const account = assertSuperAdminAccount(req, res);
+        if (!account) return;
+
+        const { currentPassword, token } = req.body;
+        const doc = await loadSuperAdminDocument(account);
+        if (!doc) {
+            return res.status(404).json({ success: false, error: 'Super admin not found' });
+        }
+
+        ensureNestedDefaults(doc);
+        if (!doc.twoFactor?.enabled) {
+            return res.status(400).json({ success: false, error: 'Two-factor authentication is not enabled' });
+        }
+
+        const passwordOk = await doc.comparePassword(currentPassword);
+        if (!passwordOk) {
+            return res.status(400).json({ success: false, error: 'Current password is incorrect' });
+        }
+
+        if (doc.twoFactor.secret && !verifyToken(token, doc.twoFactor.secret)) {
+            return res.status(400).json({ success: false, error: 'Invalid authenticator code' });
+        }
+
+        doc.twoFactor.enabled = false;
+        doc.twoFactor.secret = undefined;
+        doc.twoFactor.tempSecret = undefined;
+        doc.twoFactor.enabledAt = undefined;
+        await doc.save();
+
+        res.json({
+            success: true,
+            message: 'Two-factor authentication disabled',
+            twoFactor: { enabled: false }
+        });
+    } catch (error) {
+        console.error('Disable super admin 2FA error:', error);
+        res.status(500).json({ success: false, error: 'Server error', message: error.message });
+    }
+};


### PR DESCRIPTION
1. Start the try block.
2. Verify the requester is a super admin.
3. Read the request body.
4. Load the super admin document.
5. Ensure the account exists.
6. Ensure nested objects exist.
7. Check whether 2FA is enabled.
8. Verify the current password.
9. Verify the authenticator code.
10. Disable 2FA.
11. Remove the permanent secret.
12. Remove any temporary secret.
- This clear any incomplete setup information that may still exist.
13. Remove the activation timestamp.
14. Save the updated document.
15. Return a success response.
16. Handle unexpected errors.
17. Log the error.
18. Return a server error.