### PR TITLE
super admin

### DIFF
--- a/client/src/app/admin/adminDashboard.js
+++ b/client/src/app/admin/adminDashboard.js
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import DashboardStats from './components/DashboardStats';
 import ProductManagement from './components/Product management/ProductManagement';
 import CategoryManagement from './components/Category management/CategoryManagement';
@@ -13,6 +13,7 @@ import OrderManagement from './components/OrderManagement/OrderManagement';
 import VisualAnalyticsReports from './components/Visual analytics and reports/VisualAnalyticsReports';
 import ViewAllUsers from './components/Customer management/ViewAllUsers';
 import AdminAccount from './components/Account/AdminAccount';
+import Manage from '../superAdmin/management/Manage';
 import Sidebar from './components/Sidebar';
 
 const AdminDashboard = () => {
@@ -20,21 +21,23 @@ const AdminDashboard = () => {
   const [loading, setLoading] = useState(true);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [adminRole, setAdminRole] = useState(null);
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   // Listen for tab changes from search bar
   useEffect(() => {
     const handleTabChange = (event) => {
       const tabId = event.detail;
-      const validTabs = ['overview', 'products', 'categories', 'analytics', 'inventory', 'reviews', 'cache', 'orders', 'visual-analytics', 'customers', 'account'];
-      if (validTabs.includes(tabId)) {
-        setActiveTab(tabId);
-      }
+      const validTabs = ['overview', 'products', 'categories', 'analytics', 'inventory', 'reviews', 'cache', 'orders', 'visual-analytics', 'customers', 'account', 'super-admin'];
+      if (!validTabs.includes(tabId)) return;
+      if (tabId === 'super-admin' && adminRole !== 'super_admin') return;
+      setActiveTab(tabId);
     };
 
     window.addEventListener('admin-tab-change', handleTabChange);
     return () => window.removeEventListener('admin-tab-change', handleTabChange);
-  }, []);
+  }, [adminRole]);
 
   // Check authentication on mount
   useEffect(() => {
@@ -84,6 +87,10 @@ const AdminDashboard = () => {
               return;
             }
             console.log('Admin token validated successfully');
+            setAdminRole(data.admin.role);
+            if (data.admin.role) {
+              localStorage.setItem('adminRole', data.admin.role);
+            }
             setIsAuthenticated(true);
           } else {
             console.error('Token validation failed - invalid response:', data);
@@ -116,6 +123,20 @@ const AdminDashboard = () => {
     checkAuth();
   }, [router]);
 
+  useEffect(() => {
+    if (adminRole && adminRole !== 'super_admin' && activeTab === 'super-admin') {
+      setActiveTab('overview');
+    }
+  }, [adminRole, activeTab]);
+
+  useEffect(() => {
+    if (adminRole !== 'super_admin') return;
+    const tab = searchParams.get('tab');
+    if (tab === 'super-admin') {
+      setActiveTab('super-admin');
+    }
+  }, [adminRole, searchParams]);
+
   // Show loading while checking authentication
   if (loading) {
     return (
@@ -133,7 +154,7 @@ const AdminDashboard = () => {
     return null;
   }
 
-  const tabs = [
+  const allTabs = [
     {
       id: 'overview',
       label: 'Dashboard',
@@ -205,6 +226,14 @@ const AdminDashboard = () => {
       description: 'Profile and security'
     },
     {
+      id: 'super-admin',
+      label: 'Super Admin Panel',
+      icon: '',
+      component: Manage,
+      description: 'Staff account management',
+      superAdminOnly: true
+    },
+    {
       id: 'cache',
       label: 'Performance',
       icon: '',
@@ -212,6 +241,10 @@ const AdminDashboard = () => {
       description: 'System optimization'
     }
   ];
+
+  const tabs = allTabs.filter(
+    (tab) => !tab.superAdminOnly || adminRole === 'super_admin'
+  );
 
   const ActiveComponent = tabs.find(tab => tab.id === activeTab)?.component;
   const isRenderable = typeof ActiveComponent === 'function';

--- a/client/src/app/admin/components/Sidebar.js
+++ b/client/src/app/admin/components/Sidebar.js
@@ -137,11 +137,6 @@ export default function Sidebar({ tabs, activeTab, setActiveTab, sidebarOpen, se
                   )}
                 </button>
               )}
-              {user?.role === 'super_admin' && (
-                <a href="/superAdmin/management" className="admin-sidebar-action-btn admin-sidebar-super-link">
-                  Super Admin Panel
-                </a>
-              )}
               <div className="admin-sidebar-footer-status">
                 <div className="admin-sidebar-status-indicator"></div>
                 <span>System Online</span>

--- a/client/src/app/admin/page.js
+++ b/client/src/app/admin/page.js
@@ -1,6 +1,11 @@
+import { Suspense } from 'react';
 import AdminDashboard from './adminDashboard';
 
 export default function AdminPage() {
-  return <AdminDashboard />;
+  return (
+    <Suspense fallback={null}>
+      <AdminDashboard />
+    </Suspense>
+  );
 }
 

--- a/client/src/app/assets/css/adminAccount.css
+++ b/client/src/app/assets/css/adminAccount.css
@@ -145,6 +145,26 @@
     color: #6b7280;
     word-break: break-all;
   }
+
+  .staff-account-input--readonly,
+  .staff-account-input--readonly:disabled {
+    background-color: #f3f4f6;
+    color: #6b7280;
+    cursor: not-allowed;
+    opacity: 1;
+    border-color: #e5e7eb;
+  }
+
+  :root.dark-mode .staff-account-input--readonly,
+  :root.dark-mode .staff-account-input--readonly:disabled {
+    background-color: #374151;
+    color: #9ca3af;
+    border-color: #4b5563;
+  }
+
+  :root.dark-mode .staff-account-field-hint {
+    color: #9ca3af;
+  }
   
   .staff-account-2fa-setup,
   .staff-account-2fa-disable {

--- a/client/src/app/auth/signin/SuperAdminSignin.js
+++ b/client/src/app/auth/signin/SuperAdminSignin.js
@@ -33,7 +33,7 @@ const SuperAdminSignin = () => {
                     const data = await response.json();
                     const role = data.admin?.role || data.role;
                     if (data.success && role === 'super_admin') {
-                        router.push('/superAdmin/management');
+                        router.push('/admin?tab=super-admin');
                         return;
                     }
                 }
@@ -96,7 +96,7 @@ const SuperAdminSignin = () => {
             localStorage.setItem('adminRole', 'super_admin');
 
             await new Promise((r) => setTimeout(r, 300));
-            window.location.href = '/superAdmin/management';
+            window.location.href = '/admin?tab=super-admin';
         } catch (err) {
             console.error('Super admin login error:', err);
             setError(err.message || 'Server error. Please try again.');

--- a/client/src/app/components/accounts/StaffAccountSettings.js
+++ b/client/src/app/components/accounts/StaffAccountSettings.js
@@ -288,7 +288,16 @@ export default function StaffAccountSettings({
         <div className="staff-account-grid">
           <div className="admin-form-group">
             <label className="admin-form-label" htmlFor="staff-email">Email</label>
-            <input id="staff-email" className="admin-form-input" type="email" value={profile.email || ''} disabled />
+            <input
+              id="staff-email"
+              className="admin-form-input staff-account-input--readonly"
+              type="email"
+              value={profile.email || ''}
+              disabled
+              readOnly
+              aria-readonly="true"
+            />
+            <span className="staff-account-field-hint">Email cannot be changed here.</span>
           </div>
           <div className="admin-form-group">
             <label className="admin-form-label" htmlFor="staff-username">Username</label>

--- a/client/src/app/superAdmin/components/SuperAdminShell.js
+++ b/client/src/app/superAdmin/components/SuperAdminShell.js
@@ -8,7 +8,7 @@ import '../../assets/css/superAdmin.css';
 
 const NAV_ITEMS = [
   { href: '/superAdmin/account', label: 'My Account' },
-  { href: '/superAdmin/management', label: 'Staff Management' },
+  { href: '/admin?tab=super-admin', label: 'Staff Management' },
 ];
 
 export default function SuperAdminShell({ children }) {

--- a/client/src/app/superAdmin/management/page.js
+++ b/client/src/app/superAdmin/management/page.js
@@ -1,7 +1,14 @@
 'use client';
 
-import Manage from './Manage';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 
 export default function SuperAdminManagementPage() {
-  return <Manage />;
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace('/admin?tab=super-admin');
+  }, [router]);
+
+  return null;
 }


### PR DESCRIPTION
1. Only users with role super_admin see and can open the panel.
2. The old footer button that linked to a separate dashboard was removed.
3. Super admin sign-in and old /superAdmin/management URLs redirect to /admin?tab=super-admin.
4. If a non–super-admin tries to open the panel tab, they’re sent back to the Dashboard overview.
5. Email field grayed out.