### PR TITLE
enable 2FA

### DIFF
--- a/client/src/app/auth/signin/AdminSignin.js
+++ b/client/src/app/auth/signin/AdminSignin.js
@@ -1,11 +1,12 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
 import styles from '../../assets/css/auth.module.css';
 import '../../assets/css/buttons.css';
 import Link from 'next/link';
 import { getLoginIpPayload } from '../../utils/clientIp';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000';
 
 const AdminSignin = () => {
     const [email, setEmail] = useState('');
@@ -13,7 +14,9 @@ const AdminSignin = () => {
     const [showPassword, setShowPassword] = useState(false);
     const [error, setError] = useState(null);
     const [loading, setLoading] = useState(false);
-    const router = useRouter();
+    const [step, setStep] = useState('credentials');
+    const [twoFactorToken, setTwoFactorToken] = useState('');
+    const [totpCode, setTotpCode] = useState('');
 
     useEffect(() => {
         // Always allow account switching from admin sign-in page.
@@ -27,101 +30,151 @@ const AdminSignin = () => {
         setShowPassword(!showPassword);
     };
 
+    const completeAdminSignIn = async (data) => {
+        const token = data.accessToken || data.token;
+        if (!token) {
+            setError('Sign-in succeeded but no token was returned. Please try again.');
+            return;
+        }
+
+        localStorage.clear();
+        localStorage.setItem('adminToken', token);
+        localStorage.setItem('token', token);
+        localStorage.setItem('adminRole', data.role || 'admin');
+
+        await new Promise((resolve) => setTimeout(resolve, 300));
+
+        const finalCheck = localStorage.getItem('adminToken');
+        if (!finalCheck) {
+            localStorage.setItem('adminToken', token);
+            localStorage.setItem('token', token);
+            await new Promise((resolve) => setTimeout(resolve, 200));
+        }
+
+        window.location.href = '/admin';
+    };
+
     const handleSubmit = async (e) => {
         e.preventDefault();
         setLoading(true);
         setError(null);
-    
+
         if (!email || !password) {
-            setError("Please fill in all fields");
+            setError('Please fill in all fields');
             setLoading(false);
             return;
         }
-    
+
         const adminData = { email, password };
         const ipPayload = await getLoginIpPayload();
-    
+
         try {
-            console.log("Attempting admin login:", "http://localhost:5000/admin/signin");
-            
-            const response = await fetch("http://localhost:5000/admin/signin", {
-                method: "POST",
+            const response = await fetch(`${API_BASE}/admin/signin`, {
+                method: 'POST',
                 headers: {
-                    "Content-Type": "application/json",
+                    'Content-Type': 'application/json',
                     ...ipPayload.headers,
                 },
                 body: JSON.stringify({ ...adminData, ...ipPayload.body }),
-                credentials: "include"
+                credentials: 'include',
             });
-        
+
             let data;
             try {
                 data = await response.json();
             } catch (jsonError) {
-                console.error("Failed to parse admin login response:", jsonError);
-                setError("Invalid response from server. Please try again.");
+                console.error('Failed to parse admin login response:', jsonError);
+                setError('Invalid response from server. Please try again.');
                 setLoading(false);
                 return;
             }
-            
-            console.log("Admin login response status:", response.status);
-            console.log("Admin login response data:", data);
-        
-            // Check if admin login was successful
-            // Backend returns accessToken, but also check for token for backward compatibility
-            const token = data.accessToken || data.token;
-            if (response.ok && data && data.success === true && token) {
-                console.log("Admin signed in successfully.", data);
-                
-                // Clear all tokens first to ensure clean state
-                localStorage.clear();
-                
-                // Store admin tokens - prioritize adminToken
-                localStorage.setItem("adminToken", token);
-                localStorage.setItem("token", token); 
-                localStorage.setItem("adminRole", data.role || "admin");
-                
-                // Verify this is actually an admin response
-                if (data.role && data.role !== 'admin' && data.role !== 'super_admin') {
-                    console.error("Warning: Response does not indicate admin role");
-                }
-                
-                // Verify storage immediately
-                const storedAdminToken = localStorage.getItem("adminToken");
-                const storedToken = localStorage.getItem("token");
-                console.log("Tokens stored and verified:", {
-                    adminToken: storedAdminToken ? "Stored" : "Missing",
-                    token: storedToken ? "Stored" : "Missing",
-                    tokenLength: storedToken?.length || 0
-                });
-                
-                // Ensure tokens are persisted before redirect
-                // Use a longer delay to ensure localStorage is fully written
-                await new Promise(resolve => setTimeout(resolve, 500));
-                
-                // Double-check tokens are still there before redirect
-                const finalCheck = localStorage.getItem("adminToken");
-                if (!finalCheck) {
-                    console.error("Token lost before redirect! Retrying storage...");
-                    localStorage.setItem("adminToken", token);
-                    localStorage.setItem("token", token);
-                    await new Promise(resolve => setTimeout(resolve, 200));
-                }
-                
-                console.log("Navigating to /admin");
-                // Use hard redirect with full page reload to ensure clean state
-                window.location.href = "/admin";
+
+            if (response.ok && data?.success && data.requiresTwoFactor && data.twoFactorToken) {
+                setTwoFactorToken(data.twoFactorToken);
+                setTotpCode('');
+                setStep('twoFactor');
                 return;
             }
-            
-            // Admin login failed
-            setError(data.error || data.message || "Invalid admin credentials. Please try again.");
-        } catch (error) {
-            console.error("Admin login error:", error);
-            setError(`Server error: ${error.message}`);
+
+            const token = data.accessToken || data.token;
+            if (response.ok && data?.success === true && token) {
+                await completeAdminSignIn(data);
+                return;
+            }
+
+            setError(data.error || data.message || 'Invalid admin credentials. Please try again.');
+        } catch (err) {
+            console.error('Admin login error:', err);
+            setError(`Server error: ${err.message}`);
         } finally {
             setLoading(false);
         }
+    };
+
+    const handleTwoFactorSubmit = async (e) => {
+        e.preventDefault();
+        setLoading(true);
+        setError(null);
+
+        if (!totpCode || totpCode.length !== 6) {
+            setError('Enter the 6-digit code from your authenticator app.');
+            setLoading(false);
+            return;
+        }
+
+        const ipPayload = await getLoginIpPayload();
+
+        try {
+            const response = await fetch(`${API_BASE}/admin/signin/2fa`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    ...ipPayload.headers,
+                },
+                body: JSON.stringify({
+                    twoFactorToken,
+                    token: totpCode,
+                    ...ipPayload.body,
+                }),
+                credentials: 'include',
+            });
+
+            let data;
+            try {
+                data = await response.json();
+            } catch (jsonError) {
+                console.error('Failed to parse 2FA response:', jsonError);
+                setError('Invalid response from server. Please try again.');
+                setLoading(false);
+                return;
+            }
+
+            const token = data.accessToken || data.token;
+            if (response.ok && data?.success === true && token) {
+                await completeAdminSignIn(data);
+                return;
+            }
+
+            if (response.status === 401) {
+                setStep('credentials');
+                setTwoFactorToken('');
+                setTotpCode('');
+            }
+
+            setError(data.error || data.message || 'Invalid verification code. Please try again.');
+        } catch (err) {
+            console.error('Admin 2FA error:', err);
+            setError(`Server error: ${err.message}`);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleBackToCredentials = () => {
+        setStep('credentials');
+        setTwoFactorToken('');
+        setTotpCode('');
+        setError(null);
     };
 
     return (
@@ -139,67 +192,105 @@ const AdminSignin = () => {
 
                 <div className={styles.formPane}>
                     <div className={styles.container}>
-                        <h2 className={styles.title}>Admin Sign In</h2>
+                        <h2 className={styles.title}>
+                            {step === 'twoFactor' ? 'Two-Factor Authentication' : 'Admin Sign In'}
+                        </h2>
                         <p className={styles.subtitle} style={{ marginBottom: '1.5rem', color: '#666', fontSize: '0.9rem' }}>
-                            Access your admin dashboard
+                            {step === 'twoFactor'
+                                ? 'Enter the 6-digit code from your authenticator app.'
+                                : 'Access your admin dashboard'}
                         </p>
                         {error && <div className={styles.errorMessage}>{error}</div>}
-                        <form className={styles.form} onSubmit={handleSubmit}>
-                            <div className={styles.formGroup}>
-                                <label className={styles.label} htmlFor="admin-email">Email</label>
-                                <input
-                                    className={styles.input}
-                                    id="admin-email"
-                                    type="email"
-                                    placeholder="Enter admin email"
-                                    value={email}
-                                    onChange={(e) => setEmail(e.target.value)}
-                                    required
-                                />
-                            </div>
-                            <div className={styles.formGroup}>
-                                <label className={styles.label} htmlFor="admin-password">Password</label>
-                                <div className={styles.passwordInputContainer}>
+
+                        {step === 'credentials' ? (
+                            <form className={styles.form} onSubmit={handleSubmit}>
+                                <div className={styles.formGroup}>
+                                    <label className={styles.label} htmlFor="admin-email">Email</label>
                                     <input
                                         className={styles.input}
-                                        id="admin-password"
-                                        type={showPassword ? "text" : "password"}
-                                        placeholder="Enter admin password"
-                                        value={password}
-                                        onChange={(e) => setPassword(e.target.value)}
+                                        id="admin-email"
+                                        type="email"
+                                        placeholder="Enter admin email"
+                                        value={email}
+                                        onChange={(e) => setEmail(e.target.value)}
                                         required
                                     />
+                                </div>
+                                <div className={styles.formGroup}>
+                                    <label className={styles.label} htmlFor="admin-password">Password</label>
+                                    <div className={styles.passwordInputContainer}>
+                                        <input
+                                            className={styles.input}
+                                            id="admin-password"
+                                            type={showPassword ? 'text' : 'password'}
+                                            placeholder="Enter admin password"
+                                            value={password}
+                                            onChange={(e) => setPassword(e.target.value)}
+                                            required
+                                        />
+                                        <button
+                                            type="button"
+                                            className={styles.passwordToggle}
+                                            onClick={togglePasswordVisibility}
+                                            aria-label={showPassword ? 'Hide password' : 'Show password'}
+                                        >
+                                            {showPassword ? (
+                                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                    <path d="M15.0007 12C15.0007 13.6569 13.6576 15 12.0007 15C10.3439 15 9.00073 13.6569 9.00073 12C9.00073 10.3431 10.3439 9 12.0007 9C13.6576 9 15.0007 10.3431 15.0007 12Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                                                    <path d="M12.0012 5C7.52354 5 3.73326 7.94288 2.45898 12C3.73324 16.0571 7.52354 19 12.0012 19C16.4788 19 20.2691 16.0571 21.5434 12C20.2691 7.94288 16.4788 5 12.0012 5Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                                                </svg>
+                                            ) : (
+                                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                    <path d="M10.7302 5.07319C11.1448 5.02485 11.5684 5 11.9999 5C16.6639 5 20.3998 7.90264 21.6997 12C21.3957 12.9217 20.8589 13.7533 20.1471 14.4196M6.52026 6.51944C4.47949 7.76406 2.90205 9.69259 2.30011 12C3.60002 16.0974 7.33588 19 12.0001 19C14.037 19 15.8979 18.446 17.4805 17.4804M9.87871 9.87859C9.33576 10.4215 9.00012 11.1715 9.00012 12C9.00012 13.6569 10.3433 15 12.0001 15C12.8286 15 13.5785 14.6644 14.1215 14.1214" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                                                    <path d="M4 4L20 20" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+                                                </svg>
+                                            )}
+                                        </button>
+                                    </div>
+                                </div>
+                                <button className="button" type="submit" disabled={loading}>
+                                    {loading ? 'Signing in...' : 'Sign In'}
+                                </button>
+                                <div className={styles.authLinks} style={{ marginTop: '1rem' }}>
+                                    <p className={styles.signupRedirect} style={{ textAlign: 'center', fontSize: '0.875rem' }}>
+                                        <Link href="/" style={{ color: '#666', textDecoration: 'none' }}>
+                                            ← Back to Store
+                                        </Link>
+                                    </p>
+                                </div>
+                            </form>
+                        ) : (
+                            <form className={styles.form} onSubmit={handleTwoFactorSubmit}>
+                                <div className={styles.formGroup}>
+                                    <label className={styles.label} htmlFor="admin-2fa-code">Authenticator code</label>
+                                    <input
+                                        className={styles.input}
+                                        id="admin-2fa-code"
+                                        type="text"
+                                        inputMode="numeric"
+                                        autoComplete="one-time-code"
+                                        placeholder="000000"
+                                        maxLength={6}
+                                        value={totpCode}
+                                        onChange={(e) => setTotpCode(e.target.value.replace(/\D/g, ''))}
+                                        required
+                                    />
+                                </div>
+                                <button className="button" type="submit" disabled={loading}>
+                                    {loading ? 'Verifying...' : 'Verify and sign in'}
+                                </button>
+                                <div className={styles.authLinks} style={{ marginTop: '1rem' }}>
                                     <button
                                         type="button"
-                                        className={styles.passwordToggle}
-                                        onClick={togglePasswordVisibility}
-                                        aria-label={showPassword ? "Hide password" : "Show password"}
+                                        className={styles.forgotPassword}
+                                        onClick={handleBackToCredentials}
+                                        style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
                                     >
-                                        {showPassword ? (
-                                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                                <path d="M15.0007 12C15.0007 13.6569 13.6576 15 12.0007 15C10.3439 15 9.00073 13.6569 9.00073 12C9.00073 10.3431 10.3439 9 12.0007 9C13.6576 9 15.0007 10.3431 15.0007 12Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-                                                <path d="M12.0012 5C7.52354 5 3.73326 7.94288 2.45898 12C3.73324 16.0571 7.52354 19 12.0012 19C16.4788 19 20.2691 16.0571 21.5434 12C20.2691 7.94288 16.4788 5 12.0012 5Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-                                            </svg>
-                                        ) : (
-                                             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                             <path d="M10.7302 5.07319C11.1448 5.02485 11.5684 5 11.9999 5C16.6639 5 20.3998 7.90264 21.6997 12C21.3957 12.9217 20.8589 13.7533 20.1471 14.4196M6.52026 6.51944C4.47949 7.76406 2.90205 9.69259 2.30011 12C3.60002 16.0974 7.33588 19 12.0001 19C14.037 19 15.8979 18.446 17.4805 17.4804M9.87871 9.87859C9.33576 10.4215 9.00012 11.1715 9.00012 12C9.00012 13.6569 10.3433 15 12.0001 15C12.8286 15 13.5785 14.6644 14.1215 14.1214" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-                                              <path d="M4 4L20 20" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
-                                          </svg>
-                                        )}
+                                        ← Back to sign in
                                     </button>
                                 </div>
-                            </div>
-                            <button className="button" type="submit" disabled={loading}>
-                                {loading ? "Signing in..." : "Sign In"} 
-                            </button>
-                            <div className={styles.authLinks} style={{ marginTop: '1rem' }}>
-                                <p className={styles.signupRedirect} style={{ textAlign: 'center', fontSize: '0.875rem' }}>
-                                    <Link href="/" style={{ color: '#666', textDecoration: 'none' }}>
-                                        ← Back to Store
-                                    </Link>
-                                </p>
-                            </div>
-                        </form>
+                            </form>
+                        )}
                     </div>
                 </div>
             </div>
@@ -208,4 +299,3 @@ const AdminSignin = () => {
 };
 
 export default AdminSignin;
-

--- a/server/src/controllers/adminController.js
+++ b/server/src/controllers/adminController.js
@@ -15,6 +15,39 @@ const {
     checkUsernameAvailable
 } = require('../utilities/adminProfileHelpers');
 
+const buildAdminAuthPayload = (adminDoc) => ({
+    _id: adminDoc._id,
+    email: adminDoc.email,
+    role: adminDoc.role || 'admin',
+    isAdmin: true,
+});
+
+const issueAdminAccessToken = (adminDoc) =>
+    jwt.sign(buildAdminAuthPayload(adminDoc), process.env.JWT_SECRET, { expiresIn: '24h' });
+
+const issueAdminTwoFactorPendingToken = (adminDoc) =>
+    jwt.sign(
+        { ...buildAdminAuthPayload(adminDoc), purpose: 'admin_2fa' },
+        process.env.JWT_SECRET,
+        { expiresIn: '5m' }
+    );
+
+const respondAdminSignInSuccess = (res, adminDoc, token) => {
+    res.json({
+        success: true,
+        accessToken: token,
+        token,
+        role: adminDoc.role || 'admin',
+        admin: {
+            _id: adminDoc._id,
+            username: adminDoc.username,
+            email: adminDoc.email,
+            role: adminDoc.role,
+            lastLogin: adminDoc.lastLogin,
+        },
+    });
+};
+
 // Admin Sign Up
 exports.adminSignUp = async (req, res) => {
     try {
@@ -274,49 +307,120 @@ exports.adminSignIn = async (req, res) => {
                 });
             }
 
-            await recordAdminLogin(admin, req, { success: true });
-        } else {
-            const userDoc = await User.findById(admin._id);
-            if (userDoc) {
-                await recordAdminLogin(userDoc, req, { success: true });
-            }
         }
 
-        console.log('[ADMIN SIGNIN] Admin authenticated successfully:', admin.email, 'Role:', admin.role, 'From collection:', isUserCollection ? 'User' : 'Admin');
+        const adminDoc = isUserCollection ? await User.findById(admin._id) : admin;
+        if (!adminDoc) {
+            return res.status(404).json({
+                success: false,
+                error: 'Admin not found',
+            });
+        }
 
-        // Generate JWT token
-        const token = jwt.sign(
-            { 
-                _id: admin._id, 
-                email: admin.email,
-                role: admin.role || "admin",
-                isAdmin: true // Flag to distinguish admin tokens
-            },
-            process.env.JWT_SECRET,
-            { expiresIn: "24h" } // Extended to 24h for admin convenience
+        ensureNestedDefaults(adminDoc);
+        if (adminDoc.twoFactor?.enabled && adminDoc.twoFactor?.secret) {
+            const twoFactorToken = issueAdminTwoFactorPendingToken(adminDoc);
+            return res.json({
+                success: true,
+                requiresTwoFactor: true,
+                twoFactorToken,
+            });
+        }
+
+        await recordAdminLogin(adminDoc, req, { success: true });
+
+        console.log(
+            '[ADMIN SIGNIN] Admin authenticated successfully:',
+            adminDoc.email,
+            'Role:',
+            adminDoc.role,
+            'From collection:',
+            isUserCollection ? 'User' : 'Admin'
         );
 
-        // Return success response with admin info (excluding password)
-        // Return both accessToken and token for compatibility
-        res.json({ 
-            success: true,
-            accessToken: token,  // Primary field name for frontend
-            token: token,        // Keep for backward compatibility
-            role: admin.role || "admin",
-            admin: {
-                _id: admin._id,
-                username: admin.username,
-                email: admin.email,
-                role: admin.role,
-                lastLogin: admin.lastLogin
-            }
-        });
-
+        respondAdminSignInSuccess(res, adminDoc, issueAdminAccessToken(adminDoc));
     } catch (error) {
         console.error("Admin sign in error:", error);
         res.status(500).json({ 
             success: false,
             error: error.message || "Sign in failed" 
+        });
+    }
+};
+
+// Complete admin sign-in after TOTP verification
+exports.adminVerifyTwoFactorSignIn = async (req, res) => {
+    try {
+        if (!process.env.JWT_SECRET) {
+            return res.status(500).json({
+                success: false,
+                error: 'Server configuration error',
+            });
+        }
+
+        const { twoFactorToken, token } = req.body;
+        if (!twoFactorToken || !token) {
+            return res.status(400).json({
+                success: false,
+                error: 'Authenticator code is required',
+            });
+        }
+
+        let decoded;
+        try {
+            decoded = jwt.verify(twoFactorToken, process.env.JWT_SECRET);
+        } catch {
+            return res.status(401).json({
+                success: false,
+                error: 'Verification session expired. Please sign in again.',
+            });
+        }
+
+        if (decoded.purpose !== 'admin_2fa' || !decoded.isAdmin) {
+            return res.status(401).json({
+                success: false,
+                error: 'Invalid verification session',
+            });
+        }
+
+        const adminDoc = await loadAdminDocument(decoded);
+        if (!adminDoc) {
+            return res.status(404).json({
+                success: false,
+                error: 'Admin not found',
+            });
+        }
+
+        if (adminDoc.status !== 'active') {
+            return res.status(403).json({
+                success: false,
+                error: 'Admin account is inactive. Please contact administrator.',
+            });
+        }
+
+        ensureNestedDefaults(adminDoc);
+        if (!adminDoc.twoFactor?.enabled || !adminDoc.twoFactor?.secret) {
+            return res.status(400).json({
+                success: false,
+                error: 'Two-factor authentication is not enabled for this account',
+            });
+        }
+
+        if (!verifyToken(token, adminDoc.twoFactor.secret)) {
+            await recordAdminLogin(adminDoc, req, { success: false });
+            return res.status(400).json({
+                success: false,
+                error: 'Invalid verification code',
+            });
+        }
+
+        await recordAdminLogin(adminDoc, req, { success: true });
+        respondAdminSignInSuccess(res, adminDoc, issueAdminAccessToken(adminDoc));
+    } catch (error) {
+        console.error('Admin 2FA sign in error:', error);
+        res.status(500).json({
+            success: false,
+            error: error.message || 'Verification failed',
         });
     }
 };
@@ -577,8 +681,8 @@ exports.setupAdminTwoFactor = async (req, res) => {
             return res.status(400).json({ success: false, error: 'Two-factor authentication is already enabled' });
         }
 
-        const secret = generateSecret(); 
-        doc.twoFactor.secret = secret;
+        const secret = generateSecret();
+        doc.twoFactor.tempSecret = secret;
         await doc.save();
 
         const issuer = process.env.APP_NAME || 'Horizon E-commerce';

--- a/server/src/routes/admin.js
+++ b/server/src/routes/admin.js
@@ -4,6 +4,7 @@ const router = express.Router();
 const {
   validateAdminSignUp,
   validateAdminSignIn,
+  validateAdminTwoFactorSignIn,
   validateChangePassword,
   validateUpdateAdminProfile,
   validateAdminNotificationPreferences,
@@ -16,6 +17,7 @@ const {
 const {
   adminSignUp,
   adminSignIn,
+  adminVerifyTwoFactorSignIn,
   adminSignOut,
   getAdminProfile,
   updateAdminProfile,
@@ -39,6 +41,7 @@ router.post('/signup', ...validateAdminSignUp, handleValidationErrors, adminSign
 
 // Admin login (public route)
 router.post('/signin', ...validateAdminSignIn, handleValidationErrors, adminSignIn);
+router.post('/signin/2fa', ...validateAdminTwoFactorSignIn, handleValidationErrors, adminVerifyTwoFactorSignIn);
 
 // Admin logout (protected route)
 router.post('/signout', authMiddleware, adminSignOut);

--- a/server/src/utilities/validation.js
+++ b/server/src/utilities/validation.js
@@ -375,6 +375,14 @@ const validateAdminSignIn = [
   check("password").not().isEmpty().withMessage("Password is required"),
 ];
 
+const validateAdminTwoFactorSignIn = [
+  body("twoFactorToken").notEmpty().withMessage("Verification session is required"),
+  body("token")
+    .trim()
+    .matches(/^\d{6}$/)
+    .withMessage("A valid 6-digit authenticator code is required"),
+];
+
 const validateUpdateAdminProfile = [
   body("username")
     .optional()
@@ -474,6 +482,7 @@ module.exports = {
   validateSignIn,
   validateAdminSignUp,
   validateAdminSignIn,
+  validateAdminTwoFactorSignIn,
   handleValidationErrors,
   validate,
   validateGuestOrder,


### PR DESCRIPTION
adminController:
1. Added helpers to issue admin JWTs and build sign in responses.
2. After password check, if 2FA is enabled, returns requiresTwoFactor: true and a short-lived twoFactorToken(5 minutes) instead of a full session token.
3. adminVerifyTwoFactorSignin: Verifies the TOTP code and completes sign-in.
4. setupAdminTwoFactor: Fixed to store the secret in twoFactor.tempSecret (not twoFactor.secret) until verification.
---------------------------------------------------------------
admin.js: 
1. Imported validateAdminTwoFactorSignIn and adminVerifyTwoFactorSignIn.
2. Added route: POST /admin/signin/2fa.

---------------------------------------------------------------
validation:
1. Added validateAdminTwoFactorSignIn (validates twoFactorToken + 6-digit token).
2. Exported the new validator.
---------------------------------------------------------------
adminsignin.js:
1. Two-step sign-in UI:
- Email + password.
- 6-digit authenticator code when 2FA is required.
2. Calls POST /admin/signin/2fa to finish login.
3. Uses NEXT_PUBLIC_API_URL instead of hardcoded localhost.