### PR TITLE
notifications

### DIFF
--- a/server/src/controllers/adminController.js
+++ b/server/src/controllers/adminController.js
@@ -622,21 +622,19 @@ exports.getAdminLoginHistory = async (req, res) => {
 
 };
 
-// Update notification preferences
+// Update notification preferences (super admin own account only)
 exports.updateAdminNotificationPreferences = async (req, res) => {
     try {
         const account = assertAdminAccount(req, res);
         if (!account) return;
 
-        const updates = account.role === 'super_admin'
-            ? buildMandatorySuperAdminNotificationUpdates()
-            : buildNotificationUpdates(req.body);
-        if (Object.keys(updates).length === 0) {
-            return res.status(400).json({
+        if (account.role !== 'super_admin') {
+            return res.status(403).json({
                 success: false,
-                error: 'No valid notification preferences provided'
+                error: 'Notification preferences are managed by your super admin.',
             });
         }
+        const updates = buildMandatorySuperAdminNotificationUpdates();
 
         const Model = account.constructor?.modelName === 'User' ? User : Admin;
         const doc = await Model.findByIdAndUpdate(

--- a/server/src/controllers/superAdminController.js
+++ b/server/src/controllers/superAdminController.js
@@ -10,6 +10,7 @@ const {
     STAFF_ROLES,
     findStaffAccount
 } = require('./superAdminManagementController');
+const { normalizeNotificationPreferences } = require('../utilities/adminProfileHelpers');
 
 const ROLES = STAFF_ROLES;
 const VALID_ORDER_STATUSES = ['pending', 'processing', 'shipped', 'delivered', 'cancelled'];
@@ -28,7 +29,7 @@ const ALL_PERMISSIONS = [
 //---1. Create, edit, delete admin account (superadmin only)---
 async function createAdmin(req, res) {
     try {
-        const { email, username, password, role, permissions } = req.body;
+        const { email, username, password, role, permissions, notificationPreferences } = req.body;
         if (!email || !username || !password) {
             return res.status(400).json({ success: false, message: 'Email, username and password are required.'});
         }
@@ -47,7 +48,8 @@ async function createAdmin(req, res) {
             password,
             role: assignedRole,
             permissions: resolvedPermissions,
-            status: 'active'
+            status: 'active',
+            notificationPreferences: normalizeNotificationPreferences(notificationPreferences),
         });
         await logAudit(req.user._id,'create_admin','user',admin._id, { email, username, role: assignedRole }, req);
         const out = admin.toObject();
@@ -64,7 +66,7 @@ async function createAdmin(req, res) {
 async function updateAdmin(req, res) {
     try {
         const { adminId } = req.params;
-        const { username, email, role, permissions, status } = req.body;
+        const { username, email, role, permissions, status, notificationPreferences } = req.body;
         if (!mongoose.Types.ObjectId.isValid(adminId)) {
             return res.status(400).json({ success: false, message: 'Invalid admin ID.'});
         }
@@ -88,6 +90,9 @@ async function updateAdmin(req, res) {
             admin.permissions = permissions.filter((p) => ALL_PERMISSIONS.includes(p));
         }
         if (status != null && ['active', 'inactive'].includes(status)) admin.status = status;
+        if (notificationPreferences != null) {
+            admin.notificationPreferences = normalizeNotificationPreferences(notificationPreferences);
+        }
         await admin.save();
         await logAudit(req.user._id, 'update_admin', 'admin', admin._id, { email: admin.email, role: admin.role, accountSource: found.source }, req);
         return res.json({ success: true, data: sanitizeStaff(admin, found.source) });

--- a/server/src/models/admin.js
+++ b/server/src/models/admin.js
@@ -60,10 +60,10 @@ const adminSchema = new mongoose.Schema({
 
     // Admin notification preferences
     notificationPreferences: {
-        orderAlerts: { type: Boolean, default: true },
-        stockAlerts: { type: Boolean, default: true },
+        orderAlerts: { type: Boolean, default: false },
+        stockAlerts: { type: Boolean, default: false },
         reviewAlerts: { type: Boolean, default: false },
-        securityAlerts: { type: Boolean, default: true },
+        securityAlerts: { type: Boolean, default: false },
         weeklyReports: { type: Boolean, default: false }
     },
 

--- a/server/src/models/user.js
+++ b/server/src/models/user.js
@@ -79,10 +79,10 @@ loginHistory: [{
     success: { type: Boolean, default: true }
 }],
 notificationPreferences: {
-    orderAlerts: { type: Boolean, default: true },
-    stockAlerts: { type: Boolean, default: true },
+    orderAlerts: { type: Boolean, default: false },
+    stockAlerts: { type: Boolean, default: false },
     reviewAlerts: { type: Boolean, default: false },
-    securityAlerts: { type: Boolean, default: true },
+    securityAlerts: { type: Boolean, default: false },
     weeklyReports: { type: Boolean, default: false }
 },
 

--- a/server/src/routes/admin.js
+++ b/server/src/routes/admin.js
@@ -64,3 +64,4 @@ router.get('/orders', authMiddleware, getAllOrders);
 router.use('/categories', categoryRoutes);
 
 module.exports = router;
+  

--- a/server/src/utilities/adminProfileHelpers.js
+++ b/server/src/utilities/adminProfileHelpers.js
@@ -13,6 +13,18 @@ const MANDATORY_SUPER_ADMIN_NOTIFICATIONS = {
     weeklyReports: true,
 };
 
+const NOTIFICATION_PREFERENCE_KEYS = [
+    'orderAlerts',
+    'stockAlerts',
+    'reviewAlerts',
+    'securityAlerts',
+    'weeklyReports',
+];
+
+const EMPTY_NOTIFICATION_PREFERENCES = Object.fromEntries(
+    NOTIFICATION_PREFERENCE_KEYS.map((key) => [key, false])
+);
+
 const isAdminRole = (role) => {
     const normalized = role?.toString().toLowerCase().trim();
     return ADMIN_ROLES.includes(role) || ADMIN_ROLES.includes(normalized);
@@ -136,7 +148,7 @@ const buildProfileUpdates = (body) => {
 
 const buildNotificationUpdates = (body) => {
     const prefs = body.notificationPreferences || body;
-    const allowed = ['orderAlerts', 'stockAlerts', 'reviewAlerts', 'securityAlerts', 'weeklyReports'];
+    const allowed = NOTIFICATION_PREFERENCE_KEYS;
     const updates = {};
 
     allowed.forEach((key) => {
@@ -146,6 +158,18 @@ const buildNotificationUpdates = (body) => {
     });
 
     return updates;
+};
+
+const normalizeNotificationPreferences = (input) => {
+    const prefs = { ...EMPTY_NOTIFICATION_PREFERENCES };
+    if (input && typeof input === 'object') {
+        NOTIFICATION_PREFERENCE_KEYS.forEach((key) => {
+            if (input[key] !== undefined) {
+                prefs[key] = Boolean(input[key]);
+            }
+        });
+    }
+    return prefs;
 };
 
 const buildMandatorySuperAdminNotificationUpdates = () => {
@@ -160,12 +184,12 @@ const resolveNotificationPreferences = (doc) => {
     if (doc.role === 'super_admin') {
         return { ...MANDATORY_SUPER_ADMIN_NOTIFICATIONS };
     }
-    return doc.notificationPreferences || {
-        orderAlerts: true,
-        stockAlerts: true,
-        reviewAlerts: false,
-        securityAlerts: true,
-        weeklyReports: false,
+    if (!doc.notificationPreferences) {
+        return { ...EMPTY_NOTIFICATION_PREFERENCES };
+    }
+    return {
+        ...EMPTY_NOTIFICATION_PREFERENCES,
+        ...doc.notificationPreferences,
     };
 };
 
@@ -173,13 +197,7 @@ const ensureNestedDefaults = (doc) => {
     if (!doc.personalInfo) doc.personalInfo = {};
     if (!doc.twoFactor) doc.twoFactor = { enabled: false };
     if (!doc.notificationPreferences) {
-        doc.notificationPreferences = {
-            orderAlerts: true,
-            stockAlerts: true,
-            reviewAlerts: false,
-            securityAlerts: true,
-            weeklyReports: false
-        };
+        doc.notificationPreferences = { ...EMPTY_NOTIFICATION_PREFERENCES };
     }
     if (!Array.isArray(doc.loginHistory)) doc.loginHistory = [];
 };
@@ -278,6 +296,9 @@ module.exports = {
     buildNotificationUpdates,
     buildMandatorySuperAdminNotificationUpdates,
     MANDATORY_SUPER_ADMIN_NOTIFICATIONS,
+    NOTIFICATION_PREFERENCE_KEYS,
+    EMPTY_NOTIFICATION_PREFERENCES,
+    normalizeNotificationPreferences,
     resolveNotificationPreferences,
     ensureNestedDefaults,
     serializeAdminProfile,

--- a/server/src/utilities/validation.js
+++ b/server/src/utilities/validation.js
@@ -465,6 +465,12 @@ const validateCreateAdminAccount = [
     .withMessage("Password must be at least 6 characters long"),
   body("role").optional().isIn(STAFF_ROLES),
   body("permissions").optional().isArray(),
+  body("notificationPreferences").optional().isObject(),
+  body("notificationPreferences.orderAlerts").optional().isBoolean(),
+  body("notificationPreferences.stockAlerts").optional().isBoolean(),
+  body("notificationPreferences.reviewAlerts").optional().isBoolean(),
+  body("notificationPreferences.securityAlerts").optional().isBoolean(),
+  body("notificationPreferences.weeklyReports").optional().isBoolean(),
 ];
 
 const validateUpdateAdminAccount = [
@@ -473,6 +479,12 @@ const validateUpdateAdminAccount = [
   body("role").optional().isIn(STAFF_ROLES),
   body("permissions").optional().isArray(),
   body("status").optional().isIn(["active", "inactive"]),
+  body("notificationPreferences").optional().isObject(),
+  body("notificationPreferences.orderAlerts").optional().isBoolean(),
+  body("notificationPreferences.stockAlerts").optional().isBoolean(),
+  body("notificationPreferences.reviewAlerts").optional().isBoolean(),
+  body("notificationPreferences.securityAlerts").optional().isBoolean(),
+  body("notificationPreferences.weeklyReports").optional().isBoolean(),
 ];
 
 // Single export statement for all validators and handlers


### PR DESCRIPTION
AdminSignin:
1. Added a second sign in step when 2FA is enabled.
2. After email/password, you are asked for a 6  digit authenticator code.
3. Calls POST/admin/signin/2fa to finish login.
4. Uses NEXT_PUBLIC_API_URL instead of hardcoded localhost:5000.
5. Added "Back to sign in" if the verification session expires.
-----------------------------------------------------------------
adminController:
1. Added helpers:
- buildAdminAuthPayload
- issueAdminAccessToken
- issueAdminTwoFactorPendingToken
- respondAdminSignInSuccess
2. adminSignIn: After a valid password, if 2FA is enabled, returns { requiresTwoFactor: true, twoFactorToken } (5-minute token) instead of a full session JWT.
3. adminVerifyTwoFactorSignIn (new): Verifies the TOTP code and issues the full access token.
4. setupAdminTwoFactor: Fixed to store the secret in twoFactor.tempSecret (not twoFactor.secret) until verification.
-----------------------------------------------------------------
admin:
1. Added route: POST /admin/signin/2fa.
----------------------------------------------------------------
validation:
1. Added validateAdminTwoFactorSignIn (validates twoFactorToken + 6-digit token).Added validateAdminTwoFactorSignIn (validates twoFactorToken + 6-digit token).
----------------------------------------------------------------

StaffAccountSettings:
1. Notifications section is read-only for regular admins.
2. Removed “Save notifications” button and save handler.
3. Checkboxes are disabled — admins only see what was assigned.
4. Added message: “These notifications are assigned by your super admin.”
5. New accounts default to all unchecked until super admin sets them.
-----------------------------------------------------------------

AdminAccount:
1. Subtitle updated — no longer says admins manage notifications themselves.
-------------------------------------------------------------

Manage:
1. Added notification checkboxes on Create staff account.
2. Added notification checkboxes on Edit staff account.
3. Sends notificationPreferences to the API when creating or updating staff.