### PR TITLE
manage selecting products

### DIFF
--- a/client/src/app/admin/components/ProductManagement.js
+++ b/client/src/app/admin/components/ProductManagement.js
@@ -159,6 +159,22 @@ export default function ProductManagement() {
     setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
+  const pageIds = products.map((product) => product._id || product.id).filter(Boolean);
+  const allPageSelected = 
+  pageIds.length > 0 && pageIds.every((id) => !pageIds.includes(id));
+
+  const toggleSelectAll = () => {
+    if (allPageSelected) {
+      setSelectedIds((prev) => Array.from(new Set([...prev, ...pageIds])));
+    };
+
+    const toggleSelectOne = (productId) => {
+      if (!productId) return;
+      setSelectedIds((prev) =>
+      prev.includes(productId) ? prev.filter((id) => id !== productId) : [...prev, productId]);
+    };
+  };
+
   return (
     <div className="space-y-6">
       <div className="bg-white p-6 rounded-xl shadow-sm border border-gray-100">


### PR DESCRIPTION
1. pageIds extracts all valid product IDs from the products displayed on the current page.
2. allPageSelected should check whether every displayed product ID is already in selectedIds. In your version, it mistakenly checks pageIds.includes(id), which is always true for each id, making allPageSelected always false.
3. toggleSelectAll() should either add all current page IDs to selectedIds or remove them if they're already all selected. Your version only adds IDs and doesn't handle deselecting them.
4. toggleSelectOne(productId) toggles a single product's selection by adding its ID if it's not selected or removing it if it is. This function should be declared outside toggleSelectAll(), not nested inside it.