### PR TITLE
cache management paths and admin shell token clearing

### DIFF
--- a/client/src/app/admin/components/CacheManagement.js
+++ b/client/src/app/admin/components/CacheManagement.js
@@ -20,7 +20,7 @@ export default function CacheManagement() {
     try {
       setLoading(true);
       const token = localStorage.getItem('adminToken') || localStorage.getItem('token');
-      const response = await fetch('/api/dashboard/cache/status', {
+      const response = await fetch('/dashboard/cache/status', {
         headers: {
           'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json'
@@ -48,7 +48,7 @@ export default function CacheManagement() {
     try {
       setActionLoading(true);
       const token = localStorage.getItem('adminToken') || localStorage.getItem('token');
-      const response = await fetch('/api/dashboard/cache/refresh', {
+      const response = await fetch('/dashboard/cache/refresh', {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${token}`,
@@ -81,7 +81,7 @@ export default function CacheManagement() {
     try {
       setActionLoading(true);
       const token = localStorage.getItem('adminToken') || localStorage.getItem('token');
-      const response = await fetch('/api/dashboard/cache/clear', {
+      const response = await fetch('/dashboard/cache/clear', {
         method: 'DELETE',
         headers: {
           'Authorization': `Bearer ${token}`,

--- a/client/src/app/superAdmin/components/SuperAdminShell.js
+++ b/client/src/app/superAdmin/components/SuperAdminShell.js
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { ADMIN_API_BASE } from '@/app/utils/adminRoutes';
+import { ADMIN_API_BASE } from '@/app/utils/adminAccountApi';
 import '../../assets/css/superAdmin.css';
 
 const NAV_ITEMS = [
@@ -48,18 +48,18 @@ export default function SuperAdminShell({ children }) {
     })();
   }, [router]);
 
- const handleLogout = async () => {
-  const token = localStorage.getItem('AdminToken');
-  if (token) {
-    await fetch(`${ADMIN_API_BASE}/admin/signout`, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-    }).catch(() => {});
-  }
-  localStorage.removeItem('AdminToken');
-  localStorage.removeItem('token');
-  localStorage.removeItem('adminRole');
-  router.push('/superAdmin/signin');
+  const handleLogout = async () => {
+    const token = localStorage.getItem('adminToken');
+    if (token) {
+      await fetch(`${ADMIN_API_BASE}/admin/signout`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      }).catch(() => {});
+    }
+    localStorage.removeItem('adminToken');
+    localStorage.removeItem('token');
+    localStorage.removeItem('adminRole');
+    router.push('/superAdmin/signin');
   };
 
   if (checking) {
@@ -91,7 +91,7 @@ export default function SuperAdminShell({ children }) {
           ))}
         </nav>
         <div className="super-admin-shell-actions">
-          <Link href="/admin" className="super-admin-shell-link">Admin Dashboard"</Link>
+          <Link href="/admin" className="super-admin-shell-link">Admin Dashboard</Link>
           <Link href="/" className="super-admin-shell-link">Store</Link>
           <button type="button" className="super-admin-shell-logout" onClick={handleLogout}>Logout</button>
         </div>


### PR DESCRIPTION
1. Changed cacheManagement paths from: Api//dashboard/cache/status|refresh|clear to /dashboard/cache/status|refresh|clear.
2. SuperAdminShell  imports ADMIN_API_BASE from adminAccountApi, logout reads/clears adminToken (not AdminToken), and the stray  in Admin Dashboard is removed.