### PR TITLE
convert security policy

### DIFF
--- a/client/src/app/superAdmin/management/SecurityPolicyPanel.js
+++ b/client/src/app/superAdmin/management/SecurityPolicyPanel.js
@@ -19,3 +19,22 @@ const DEFAULT_FORM = {
   ipAllowlistText: '',
   apiKeyDefaultExpiryDays: 90,
 };
+
+function policyToForm(policy = {}) {
+  const list = Array.isArray(policy.ipAllowlist) ? policy.ipAllowlist : [];
+  return {
+    passwordMinLength: policy.passwordMinLength ?? DEFAULT_FORM.passwordMinLength,
+    passwordRequireUppercase: Boolean(policy.passwordRequireUppercase ?? DEFAULT_FORM.passwordRequireUppercase),
+    passwordRequireNumber: Boolean(policy.passwordRequireNumber ?? DEFAULT_FORM.passwordRequireNumber),
+    passwordRequireSpecial: Boolean(policy.passwordRequireSpecial ?? DEFAULT_FORM.passwordRequireSpecial),
+    sessionTimeoutMinutes: policy.sessionTimeoutMinutes ?? DEFAULT_FORM.sessionTimeoutMinutes,
+    maxLoginAttempts: policy.maxLoginAttempts ?? DEFAULT_FORM.maxLoginAttempts,
+    lockoutDurationMinutes: policy.lockoutDurationMinutes ?? DEFAULT_FORM.lockoutDurationMinutes,
+    requireTwoFactorForAdmins: Boolean(policy.requireTwoFactorForAdmins ?? DEFAULT_FORM.requireTwoFactorForAdmins),
+    requireTwoFactorForSuperAdmins: Boolean(
+      policy.requireTwoFactorForSuperAdmins ?? DEFAULT_FORM.requireTwoFactorForSuperAdmins
+    ),
+    ipAllowlistText: list.join('\n'),
+    apiKeyDefaultExpiryDays: policy.apiKeyDefaultExpiryDays ?? DEFAULT_FORM.apiKeyDefaultExpiryDays,
+  };
+}


### PR DESCRIPTION
1. policyToForm() is a conversion function that prepares backend data for the React form. It ensures every field has a safe value by falling back to DEFAULT_FORM when data is missing, converts values like 0, 1, null, or undefined into proper booleans where needed, and transforms the ipAllowlist array into a newline-separated string so it can be displayed and edited naturally in a textarea. This keeps the form code simple because it always receives a complete, predictable object regardless of what the backend returns.