### PR TITLE
converts the IP allow list and loads the current policy

### DIFF
--- a/client/src/app/superAdmin/management/SecurityPolicyPanel.js
+++ b/client/src/app/superAdmin/management/SecurityPolicyPanel.js
@@ -38,3 +38,36 @@ function policyToForm(policy = {}) {
     apiKeyDefaultExpiryDays: policy.apiKeyDefaultExpiryDays ?? DEFAULT_FORM.apiKeyDefaultExpiryDays,
   };
 }
+
+function parseIpAllowlist(text) {
+  return String(text || '')
+    .split(/[\n,]+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+export default function SecurityPolicyPanel() {
+  const [form, setForm] = useState(DEFAULT_FORM);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(null);
+  const [submitLoading, setSubmitLoading] = useState(false);
+  const [submitError, setSubmitError] = useState(null);
+  const [successMessage, setSuccessMessage] = useState(null);
+
+  const fetchPolicy = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const res = await fetch(POLICY_URL, { headers: getAdminAuthHeaders() });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || data.success === false) {
+        throw new Error(data.message || data.error || Failed to load security policy (${res.status}));
+      }
+      setForm(policyToForm(data.data || {}));
+    } catch (err) {
+      setLoadError(err.message || 'Failed to load security policy');
+      setForm(DEFAULT_FORM);
+    } finally {
+      setLoading(false);
+    }
+  }, []);


### PR DESCRIPTION
This code prepares and loads security policy. parseIpAllowlist() converts the user's multiline or comma-separated IP entries into a clean array for the backend by splitting on commas or newlines, trimming whitespace, and removing blank entries. SecurityPolicyPanel then initializes the page state and defines fetchPolicy(), which retrieves the current policy from the server, converts it into a form-friendly structure with policyToForm(), handles any errors gracefully, falls back to default settings if needed, and always clears the loading state when finished. This gives the user a reliable settings page that works even if the backend request fails.