### PR TITLE
a number input field

### DIFF
--- a/client/src/app/superAdmin/management/SecurityPolicyPanel.js
+++ b/client/src/app/superAdmin/management/SecurityPolicyPanel.js
@@ -291,6 +291,23 @@ export default function SecurityPolicyPanel() {
                 required
                 className="admin-form-input"
               />
+              </div>
+            <div className="admin-form-group">
+              <label className="admin-form-label" htmlFor="lockoutDurationMinutes">
+                Lockout duration (minutes)
+              </label>
+              <input
+                id="lockoutDurationMinutes"
+                type="number"
+                name="lockoutDurationMinutes"
+                value={form.lockoutDurationMinutes}
+                onChange={handleNumberChange}
+                min={5}
+                max={1440}
+                required
+                className="admin-form-input"
+              />
+            </div>
             </div>
       </form>
       </div>


### PR DESCRIPTION
This field allows the Super Admin to specify how many minutes an account should remain locked after exceeding the maximum number of failed login attempts. It is a controlled React input, validates that the value is between 5 and 1440 minutes, updates form.lockoutDurationMinutes whenever it changes, and is included in the security policy sent to the backend when the form is saved.